### PR TITLE
fix build issue see description

### DIFF
--- a/power/Android.bp
+++ b/power/Android.bp
@@ -22,7 +22,7 @@ cc_binary {
         "service.cpp",
     ],
 
-    include_dirs: ["hardware/samsung/hidl/light/include"],
+    include_dirs: ["hardware/samsung/aidl/light/include"],
     local_include_dirs: ["include"],
 
     shared_libs: [
@@ -31,7 +31,6 @@ cc_binary {
         "libhidlbase",
         "libutils",
         "android.hardware.power@1.0",
-        "vendor.lineage.power@1.0",
     ],
 
     static_libs: ["libc++fs"],


### PR DESCRIPTION
when you build with this tree (lineage 18.1) with hardware (lineage-18.1) you got 2 problem:
1) undifined vendor.lineage.power@1.0
2) light/include path not found