### PR TITLE
fix build issue

### DIFF
--- a/power/Android.bp
+++ b/power/Android.bp
@@ -22,7 +22,7 @@ cc_binary {
         "service.cpp",
     ],
 
-    include_dirs: ["hardware/samsung/hidl/light/include"],
+    include_dirs: ["hardware/samsung/aidl/light/include"],
     local_include_dirs: ["include"],
 
     shared_libs: [
@@ -31,7 +31,6 @@ cc_binary {
         "libhidlbase",
         "libutils",
         "android.hardware.power@1.0",
-        "vendor.lineage.power@1.0",
     ],
 
     static_libs: ["libc++fs"],


### PR DESCRIPTION
hardware 19.1 doesnt support vendor.lineage.power@1.0 anymore and light path was changed to aidl not idle